### PR TITLE
Add null check for outliningManager

### DIFF
--- a/RelativeNumber/RelativeNumber.cs
+++ b/RelativeNumber/RelativeNumber.cs
@@ -219,6 +219,10 @@
         private int CountHiddenLines(int start, int end)
         {
             if (start > end) return 0;
+            
+            // outliningManager will be null when outlining is not supported, such as in a git diff view
+            if (outliningManager == null) return 0;
+
             var hiddenLines = outliningManager.GetCollapsedRegions(new SnapshotSpan(textView.TextSnapshot, start, end - start), true);
             var hiddenLineCount = 0;
             foreach (var hiddenLine in hiddenLines)


### PR DESCRIPTION
There are some views that do not support outlining, and so the
outliningManager injected into RelativeNumber will be null.  An instance
of where this fails (with a NullReferenceException) is trying to do a
diff on a change in git.  This crashes VS (both VS2013 and VS2015 preview)
