### PR TITLE
Implement custom foreground/background color for current line

### DIFF
--- a/RelativeNumber/CurrentLineFormatDefinition.cs
+++ b/RelativeNumber/CurrentLineFormatDefinition.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Linq;
+using System.Text;
+using System.Windows.Media;
+using Microsoft.VisualStudio.Text.Classification;
+using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.VisualStudio.Utilities;
+
+namespace RelativeNumber
+{
+    [Export(typeof(EditorFormatDefinition))]
+    [ContentType("text")]
+    [TextViewRole(PredefinedTextViewRoles.Document)]
+    [Name(CurrentLineFormatDefinition.Name)]
+    [UserVisible(true)]
+    internal class CurrentLineFormatDefinition : ClassificationFormatDefinition
+    {
+        public const string Name = "RelativeNumber/CurrentLineNumber";
+
+        public CurrentLineFormatDefinition()
+        {
+            this.DisplayName = "Relative Number - Current Line";
+            this.ForegroundColor = null;
+            this.BackgroundColor = null;
+            this.IsBold = null;
+        }
+    }
+}

--- a/RelativeNumber/RelativeNumber.cs
+++ b/RelativeNumber/RelativeNumber.cs
@@ -116,6 +116,10 @@
             var fontFamily = textView.FormattedLineSource.DefaultTextProperties.Typeface.FontFamily;
             var fontSize = textView.FormattedLineSource.DefaultTextProperties.FontRenderingEmSize * (textView.ZoomLevel / 100);
 
+            var currentLineDefinition = formatMap.GetProperties(CurrentLineFormatDefinition.Name);
+            var currentLineBackColor = currentLineDefinition.GetValue<SolidColorBrush>(EditorFormatDefinition.BackgroundBrushId, defaultValue: backColor);
+            var currentLineForeColor = currentLineDefinition.GetValue<SolidColorBrush>(EditorFormatDefinition.ForegroundBrushId, defaultValue: foreColor);
+
             // Setup line indexes
             var currentCursorLineNumber = CursorLineNumber;
             var viewTotalLines = textView.TextViewLines.Count;
@@ -162,6 +166,8 @@
             var counter = 0;
             for (var i = 0; i < viewTotalLines; i++)
             {
+                var lineForeColor = foreColor;
+                var lineBackColor = backColor;
                 var width = numberCharactersLineCount;
                 var currentLoopLine = textView.TextSnapshot.GetLineFromPosition(textView.TextViewLines[i].Start);
                 var currentLoopLineNumber = currentLoopLine.LineNumber;
@@ -178,6 +184,12 @@
                     displayNumber = lineNumbers.Count - 1 >= indx ? lineNumbers[indx] : lineNumbers[i];
                     width = HasFocus ? numberCharactersLineCount * -1 : numberCharactersLineCount;
                     counter += 1;
+
+                    if (HasFocus)
+                    {
+                        lineForeColor = currentLineForeColor;
+                        lineBackColor = currentLineBackColor;
+                    }
                 }
                 else
                 {
@@ -187,7 +199,7 @@
                     counter += 1;
                 }
 
-                var lineNumber = ConstructLineNumber(displayNumber, width, fontFamily, fontSize, foreColor);
+                var lineNumber = ConstructLineNumber(displayNumber, width, fontFamily, fontSize, lineForeColor, lineBackColor);
                 previousLineNumber = currentLoopLineNumber;
 
                 var top = (textView.TextViewLines[i].TextTop - textView.ViewportTop) * (textView.ZoomLevel / 100);
@@ -251,13 +263,14 @@
             return string.Format(CultureInfo.CurrentCulture, "{0," + width + "}", lineNumber);
         }
 
-        private static Label ConstructLineNumber(int? displayNumber, int width, FontFamily fontFamily, double fontSize, Brush foreColor)
+        private static Label ConstructLineNumber(int? displayNumber, int width, FontFamily fontFamily, double fontSize, Brush foreColor, Brush backColor)
         {
             var label = new Label
             {
                 FontFamily = fontFamily,
                 FontSize = fontSize,
                 Foreground = foreColor,
+                Background = backColor,
                 Content = FormatNumber(width, displayNumber),
                 Padding = new Thickness(0, 0, 0, 0)
             };

--- a/RelativeNumber/RelativeNumber.csproj
+++ b/RelativeNumber/RelativeNumber.csproj
@@ -82,9 +82,11 @@
     <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CurrentLineFormatDefinition.cs" />
     <Compile Include="RelativeNumber.cs" />
     <Compile Include="RelativeNumberFactory.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ResourceDictionaryExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="icon.ico">

--- a/RelativeNumber/ResourceDictionaryExtensions.cs
+++ b/RelativeNumber/ResourceDictionaryExtensions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+
+namespace RelativeNumber
+{
+    public static class ResourceDictionaryExtensions
+    {
+        public static T GetValue<T>(this ResourceDictionary dictionary, object key, T defaultValue)
+        {
+            if (dictionary.Contains(key))
+            {
+                return (T)dictionary[key];
+            }
+            return defaultValue;
+        }
+    }
+}


### PR DESCRIPTION
Added a configuration option for the current cursor line's foreground and background colors:

![fonts_and_colors](https://cloud.githubusercontent.com/assets/90451/5572557/6114c176-8f6e-11e4-8ec8-52c422774b39.png)

Render the current cursor line with the custom settings:

![current_line](https://cloud.githubusercontent.com/assets/90451/5572535/dd68e1e0-8f6d-11e4-93f2-f4f944009952.png)

The current cursor line will fall back to the "Line Numbers" colors if values are not specified.

Thanks for the fantastic extension!