### PR TITLE
Fix solution to build debug when selected

### DIFF
--- a/RelativeNumber.sln
+++ b/RelativeNumber.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.30110.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.26228.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RelativeNumber", "RelativeNumber\RelativeNumber.csproj", "{6224C2E5-FCD9-447E-98BF-A782C6279542}"
 EndProject
@@ -11,8 +11,8 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{6224C2E5-FCD9-447E-98BF-A782C6279542}.Debug|Any CPU.ActiveCfg = Release|Any CPU
-		{6224C2E5-FCD9-447E-98BF-A782C6279542}.Debug|Any CPU.Build.0 = Release|Any CPU
+		{6224C2E5-FCD9-447E-98BF-A782C6279542}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6224C2E5-FCD9-447E-98BF-A782C6279542}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6224C2E5-FCD9-447E-98BF-A782C6279542}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6224C2E5-FCD9-447E-98BF-A782C6279542}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection


### PR DESCRIPTION
Even when Debug was selected, the Release version was being built and run. This changes it so that when Release is selected, Release is built and run and vice versa for Debug.